### PR TITLE
Fixed a bug where the browser would skip logging out

### DIFF
--- a/backend/api/src/routes/authentication.js
+++ b/backend/api/src/routes/authentication.js
@@ -84,7 +84,7 @@ const routes = async function(fastify) {
 
     fastify.get("/signout", { schema: Signout }, async (request, response) => {
         request.session.destroy()
-        response.redirect(308, env.CORS_URL + "/login") 
+        response.redirect(302, env.CORS_URL + "/login")
     })
 }
 

--- a/backend/api/src/routes/schema/authentication.js
+++ b/backend/api/src/routes/schema/authentication.js
@@ -17,7 +17,7 @@ const Signup = { //json schemea
 }
 
 const Signout = {
-    response: { "308": Type.Null() }
+    response: { "302": Type.Null() }
 }
 
 module.exports = { Login, Signup, Signout }


### PR DESCRIPTION
308s are cached by default. Meaning that instead of going to the url and running the code the browser would just short circuit and go to the url, and not run the logout code.

Changing to a 302 fixes that